### PR TITLE
Add missing require time in check.rb

### DIFF
--- a/lib/updown/check.rb
+++ b/lib/updown/check.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module Updown
   class Check
     attr_accessor :token, :url, :last_status, :uptime, :down, :down_since, :error, :period, :apdex_t, :enabled, :published, :last_check_at, :next_check_at, :ssl_tested_at, :ssl_valid, :ssl_error


### PR DESCRIPTION
I got the following error when running updown status without this fix : 

```
~ ❯❯❯ updown status                                                                                                                                                                                                                                                           ⏎
/Users/adrien/.gem/ruby/2.1.5/gems/updown-0.2.0/lib/updown/check.rb:27:in `initialize': undefined method `parse' for Time:Class (NoMethodError)
    from /Users/adrien/.gem/ruby/2.1.5/gems/updown-0.2.0/lib/updown/check.rb:7:in `new'
    from /Users/adrien/.gem/ruby/2.1.5/gems/updown-0.2.0/lib/updown/check.rb:7:in `block in all'
    from /Users/adrien/.gem/ruby/2.1.5/gems/updown-0.2.0/lib/updown/check.rb:6:in `map'
    from /Users/adrien/.gem/ruby/2.1.5/gems/updown-0.2.0/lib/updown/check.rb:6:in `all'
    from /Users/adrien/.gem/ruby/2.1.5/gems/updown-0.2.0/lib/updown/cli.rb:12:in `status'
    from /Users/adrien/.gem/ruby/2.1.5/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/adrien/.gem/ruby/2.1.5/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/adrien/.gem/ruby/2.1.5/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Users/adrien/.gem/ruby/2.1.5/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /Users/adrien/.gem/ruby/2.1.5/gems/updown-0.2.0/bin/updown:8:in `<top (required)>'
    from /Users/adrien/.gem/ruby/2.1.5/bin/updown:23:in `load'
    from /Users/adrien/.gem/ruby/2.1.5/bin/updown:23:in `<main>'
```
