### PR TITLE
Added support for get single check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Updown::Check.all
 # => [<Updown::Check>, <Updown::Check>, … ]
 ```
 
+Retrieve a specific check:
+
+```ruby
+Updown::Check.get check_token
+# => <Updown::Check>
+```
+
 List downtimes for a specific check (paginated, 100 per call):
 
 ```ruby

--- a/lib/updown/call.rb
+++ b/lib/updown/call.rb
@@ -21,6 +21,10 @@ module Updown
       process { Call.resource['checks'].post(attributes) }
     end
 
+    def self.get_check(token, attributes={})
+      process { Call.resource["checks/#{token}"].get(attributes) }
+    end
+
     def self.update_check(token, attributes={})
       process { Call.resource["checks/#{token}"].put(attributes) }
     end

--- a/lib/updown/check.rb
+++ b/lib/updown/check.rb
@@ -14,6 +14,10 @@ module Updown
       Check.new Updown::Call.create_check(attributes.merge(url: url))
     end
 
+    def self.get(token, attributes = {})
+      Check.new Updown::Call.get_check(token, attributes)
+    end
+
     def initialize(json)
       @token         = json['token']
       @url           = json['url']

--- a/lib/updown/version.rb
+++ b/lib/updown/version.rb
@@ -1,3 +1,3 @@
 module Updown
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Recently, updown.io added an endpoint for getting a single check. The endpoint is implemented here as the class method `Updown::Check.get`, which returns a new `Check` based on the given token.

I have also incremented the version to encourage the gem author to push this new feature to rubygems.org at his earliest convenience.
