### PR TITLE
Update exception message when no 'error' key into response.

### DIFF
--- a/lib/updown/call.rb
+++ b/lib/updown/call.rb
@@ -37,7 +37,7 @@ module Updown
       JSON.parse yield
     rescue RestClient::BadRequest, RestClient::Unauthorized, RestClient::ResourceNotFound => e
       result = (JSON.parse(e.response) rescue {})
-      raise Updown::Error.new(result['error'] || e.reponse)
+      raise Updown::Error.new(result['error'] || e.response)
     end
 
   end


### PR DESCRIPTION
Hi,

When a RestClient exception is caught and no key `error` is present into response hash, shouldn't we set the exception message with `e.response` value instead of `e.reponse` (I'm not sure it exists, isn't it ?)

Thank you.
